### PR TITLE
cmd/migrate: Add target for linux/amd64

### DIFF
--- a/cmd/migrate/BUILD.bazel
+++ b/cmd/migrate/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -15,5 +15,12 @@ go_library(
 go_binary(
     name = "migrate",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_cross_binary(
+    name = "linux_amd64",
+    platform = "@io_bazel_rules_go//go/toolchain:linux_amd64",
+    target = ":migrate",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
cmd/migrate: Add target for linux/amd64
